### PR TITLE
Set all Home.jsx users as admin client type

### DIFF
--- a/src/contexts/MatchContext.jsx
+++ b/src/contexts/MatchContext.jsx
@@ -116,11 +116,8 @@ export const MatchProvider = ({ children }) => {
   // Khởi tạo socket connection
   const initializeSocket = useCallback(async (accessCode) => {
     try {
-      // Xác định client type dựa trên user role
-      let clientType = 'client'; // mặc định
-      if (user?.role === 'admin') {
-        clientType = 'admin';
-      }
+      // Tất cả người vào Home.jsx đều là admin (theo yêu cầu)
+      let clientType = 'admin';
 
       // Tránh khởi tạo socket trùng lặp
       if (socketService.getConnectionStatus().accessCode === accessCode &&


### PR DESCRIPTION
## Purpose
The user requested to simplify the client type logic so that all users accessing Home.jsx are treated as admin clients, regardless of their authentication method (username/password + access code or just access code). This removes the distinction based on user roles for Home.jsx access.

## Code changes
- Removed conditional logic that checked `user?.role === 'admin'` in `initializeSocket` function
- Set `clientType` to always be `'admin'` for all users in Home.jsx
- Added Vietnamese comment explaining that all Home.jsx users are treated as admin per requirements
- Simplified the client type determination logic in MatchContext.jsx

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/f2ace27f88ee45de8c5a674d1dbf9bc5/glow-haven)

👀 [Preview Link](https://f2ace27f88ee45de8c5a674d1dbf9bc5-glow-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f2ace27f88ee45de8c5a674d1dbf9bc5</projectId>-->
<!--<branchName>glow-haven</branchName>-->