### PR TITLE
Reorganize timer controls and add 40'/45' countdown options

### DIFF
--- a/src/components/sections/MatchManagementSection.jsx
+++ b/src/components/sections/MatchManagementSection.jsx
@@ -1084,10 +1084,10 @@ const MatchManagementSection = () => {
                     toast.warning('⚠️ Vui lòng nhập thời gian hợp lệ!');
                   }
                 }}
-                disabled={(!quickCustomMinutes || quickCustomMinutes === '0') && (!quickCustomSeconds || quickCustomSeconds === '0')}
+                disabled={!quickCustomMinutes || quickCustomMinutes === '0'}
                 title="Áp dụng"
               >
-                ĐẾM T
+                OK
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Purpose
The user requested to reorganize the match timer interface by:
- Moving the "Nghỉ giữa hiệp" (halftime break) button below other options
- Adding new countdown options for 40' and 45' minutes
- Simplifying the custom timer input to only accept minutes (removing seconds)
- Replacing the custom timer label with increment/decrement buttons and an OK button

## Code changes
- **Moved halftime button**: Relocated "NGHỈ GIỮA HIỆP" button from top controls to bottom of timer options grid
- **Added new timer options**: Implemented 40' and 45' countdown buttons with purple and rose gradient styling
- **Simplified custom timer input**: 
  - Removed seconds input field and label
  - Added +/- buttons for minute increment/decrement
  - Changed submit button text from "ĐẾM T" to "OK"
  - Updated logic to only handle minutes (defaults to :00 seconds)
- **UI improvements**: Reorganized match info section layout and improved responsive design
- **Minor fixes**: Corrected some character encoding issues in Vietnamese comments

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/2e522be690fb4399bf04be9f39a7cb6f/zen-realm)

👀 [Preview Link](https://2e522be690fb4399bf04be9f39a7cb6f-zen-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e522be690fb4399bf04be9f39a7cb6f</projectId>-->
<!--<branchName>zen-realm</branchName>-->