### PR TITLE
Fix audio listener registration in DisplayController

### DIFF
--- a/src/components/display/DisplayController.jsx
+++ b/src/components/display/DisplayController.jsx
@@ -32,6 +32,9 @@ const DisplayController = () => {
 
   // Lắng nghe event audio_control từ backend để phát voice trọng tài
   useEffect(() => {
+    // Chỉ đăng ký listener khi đã kết nối socket
+    if (!isInitialized) return;
+
     const handleAudioControl = (data) => {
       console.log('🚿 [DisplayController] Nhận audio từ socket:', data);
 
@@ -52,12 +55,13 @@ const DisplayController = () => {
       }
     };
 
+    console.log('📡 [DisplayController] Đăng ký audio listener sau khi socket đã kết nối');
     socketService.onAudioControl(handleAudioControl);
 
     return () => {
       socketService.off('audio_control', handleAudioControl);
     };
-  }, [playRefereeVoice]);
+  }, [playRefereeVoice, isInitialized]);
 
   // Khởi tạo kết nối socket
   useEffect(() => {


### PR DESCRIPTION
## Purpose
User was debugging why console logs for referee voice commands weren't appearing in DisplayController.jsx despite the backend successfully sending the audio data. The issue was that the audio event listener was being registered before the socket connection was fully initialized.

## Code changes
- Added socket initialization check before registering audio listener
- Only register `audio_control` listener when `isInitialized` is true
- Added `isInitialized` to useEffect dependency array
- Added debug console log to confirm listener registration timing

This ensures the audio event listener is properly registered after socket connection is established, fixing the missing console logs issue.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/92060e2226b34c45af1a13f6b1725182/echo-home)

👀 [Preview Link](https://92060e2226b34c45af1a13f6b1725182-echo-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>92060e2226b34c45af1a13f6b1725182</projectId>-->
<!--<branchName>echo-home</branchName>-->