### PR TITLE
Fix audio control socket listeners for display controller

### DIFF
--- a/src/contexts/AudioContext.jsx
+++ b/src/contexts/AudioContext.jsx
@@ -522,6 +522,9 @@ export const AudioProvider = ({ children }) => {
         if (socketService.socket) {
           console.log('📡 [AudioContext] Socket exists, registering listeners...');
 
+          // Setup debug listeners trước
+          setupGlobalDebugListeners();
+
           // Đăng ký TẤT CẢ possible event names
           socketService.on('audio_control', handleAudioControl);
           socketService.on('audio_control_broadcast', handleAudioControl);


### PR DESCRIPTION
## Purpose

The user was experiencing issues where the display controller route `/accesscode` was not playing audio despite the backend sending audio control commands. The audio control events were not being properly received in the AudioContext, preventing audio playback on the display controller interface.

## Code changes

**Enhanced socket listener setup in AudioContext.jsx:**

- **Aggressive listener registration**: Changed from waiting for socket readiness to immediately attempting listener setup
- **Expanded audio command support**: Added handlers for `PLAY_AUDIO`, `STOP_AUDIO`, `ENABLE_AUDIO`, and `DISABLE_AUDIO` commands beyond just `PLAY_REFEREE_VOICE`
- **Multiple event name coverage**: Added listeners for various possible audio event names (`audio_command`, `audio_update`, `audio_control_broadcast`, etc.)
- **Global debug listeners**: Added comprehensive debugging to catch all audio-related socket events
- **Persistent retry mechanism**: Implemented continuous retry every second instead of timing out after 10 seconds
- **Improved error handling**: Better logging and error catching for listener registration

These changes ensure that audio control commands from the backend are properly received and processed by the display controller interface.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/65cdd573a19c40908417772cde3a2bdd/vibe-haven)

👀 [Preview Link](https://65cdd573a19c40908417772cde3a2bdd-vibe-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>65cdd573a19c40908417772cde3a2bdd</projectId>-->
<!--<branchName>vibe-haven</branchName>-->