### PR TITLE
Replace ScoreboardBelow with ScoreboardBelowNew component

### DIFF
--- a/src/components/display/DisplayController.jsx
+++ b/src/components/display/DisplayController.jsx
@@ -93,7 +93,10 @@ const DisplayController = () => {
       case 'scoreboard':
         return <ScoreboardAbove accessCode={accessCode} />;
       case 'scoreboard_below':
-        return <ScoreboardBelow accessCode={accessCode} />;
+        return <ScoreboardBelowNew
+          accessCode={accessCode}
+          type={displaySettings.selectedSkin || 1}
+        />;
       case 'poster':
       default:
         const posterType = displaySettings.selectedPoster?.id || displaySettings.selectedPoster;

--- a/src/components/display/DisplayController.jsx
+++ b/src/components/display/DisplayController.jsx
@@ -15,7 +15,7 @@ import PosterXanhDuong from '../../pages/Poster-xanhduong';
 import Intro from '../introduce/Intro';
 import HalfTime from '../halftime/HalfTime';
 import ScoreboardAbove from '../scoreboard_preview/ScoreboardAbove';
-import ScoreboardBelow from '../scoreboard_preview/ScoreboardBelow';
+import ScoreboardBelowNew from '../scoreboard_preview/ScoreboardBelowNew';
 
 const DisplayController = () => {
   const { accessCode } = useParams();


### PR DESCRIPTION
## Purpose
Update the display controller to use the new ScoreboardBelowNew component instead of ScoreboardBelow, and integrate template type selection functionality based on the skin number from MatchManagementSection.

## Code changes
- **Component replacement**: Changed import from `ScoreboardBelow` to `ScoreboardBelowNew` in DisplayController.jsx
- **Props enhancement**: Added `type` prop to ScoreboardBelowNew component that passes `displaySettings.selectedSkin` (defaulting to 1)
- **Template integration**: The type prop corresponds to the 4 template types (skinNumber) available in the MatchManagementSection's inline template selection

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 115`

🔗 [Edit in Builder.io](https://builder.io/app/projects/97c65506a1a94f0a96c8fa5a8089379e/glow-nest)

👀 [Preview Link](https://97c65506a1a94f0a96c8fa5a8089379e-glow-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>97c65506a1a94f0a96c8fa5a8089379e</projectId>-->
<!--<branchName>glow-nest</branchName>-->