### PR TITLE
Fix team kit colors and marquee settings in scoreboard

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -25,17 +25,26 @@ const ScoreboardBelowNew = ({
         matchTime: matchData?.matchTime || "00:00",
         period: matchData?.period || "Chưa bắt đầu",
         status: matchData?.status || "waiting",
-        teamAKitColor: "#FF0000", // Default colors - these could be added to context later
-        teamBKitColor: "#0000FF",
+        teamAKitColor: matchData?.teamAKitColor || "#FF0000", // Get from match data
+        teamBKitColor: matchData?.teamBKitColor || "#0000FF", // Get from match data
         leagueLogo: "/api/placeholder/40/40"
     };
 
-    // Get marquee data
+    // Get marquee data from context (updated via Clock Settings)
     const scrollData = {
-        text: marqueeData?.text || "TRỰC TIẾP BÓNG ĐÁ",
-        color: marqueeData?.color || "#FFFFFF",
-        bgColor: "#FF0000",
-        repeat: 3
+        text: marqueeData?.text || "TRỰC TI��P BÓNG ĐÁ",
+        color: marqueeData?.color === 'white-black' ? '#FFFFFF' :
+               marqueeData?.color === 'black-white' ? '#000000' :
+               marqueeData?.color === 'white-blue' ? '#FFFFFF' :
+               marqueeData?.color === 'white-red' ? '#FFFFFF' :
+               marqueeData?.color === 'white-green' ? '#FFFFFF' : "#FFFFFF",
+        bgColor: marqueeData?.color === 'white-black' ? '#000000' :
+                 marqueeData?.color === 'black-white' ? '#FFFFFF' :
+                 marqueeData?.color === 'white-blue' ? '#2563eb' :
+                 marqueeData?.color === 'white-red' ? '#dc2626' :
+                 marqueeData?.color === 'white-green' ? '#16a34a' : "#FF0000",
+        repeat: 3,
+        mode: marqueeData?.mode || 'none'
     };
 
     // Determine if we should show match time based on status

--- a/src/components/sections/MatchManagementSection.jsx
+++ b/src/components/sections/MatchManagementSection.jsx
@@ -38,6 +38,7 @@ const MatchManagementSection = ({ isActive = true }) => {
 
     updateView,
     resumeTimer,
+    updateMarquee,
 
     // Logo update functions
     updateSponsors,

--- a/src/components/sections/MatchManagementSection.jsx
+++ b/src/components/sections/MatchManagementSection.jsx
@@ -684,25 +684,34 @@ const MatchManagementSection = ({ isActive = true }) => {
                   title: matchTitle,
                   time: matchInfo.startTime
                 });
-                // Console log màu áo quần để debug
-                console.log('Màu áo quần:', {
-                  teamA: {
-                    shirtColor: teamAInfo.shirtColor || '#ff0000',
-                    pantsColor: teamAInfo.pantsColor || '#ff0000'
-                  },
-                  teamB: {
-                    shirtColor: teamBInfo.shirtColor || '#000000',
-                    pantsColor: teamBInfo.pantsColor || '#000000'
-                  }
+                              // Emit team kit colors via socket
+                const teamColorsData = {
+                  teamAKitColor: teamAInfo.shirtColor || '#ff0000',
+                  teamBKitColor: teamBInfo.shirtColor || '#000000'
+                };
+
+                // Update team kit colors in MatchContext
+                updateMatchInfo({
+                  ...teamColorsData,
+                  startTime: matchInfo.startTime,
+                  stadium: matchInfo.location,
+                  matchDate: matchInfo.matchDate || new Date().toISOString().split('T')[0],
+                  title: matchTitle,
+                  time: matchInfo.startTime,
+                  liveUnit: liveUnit
                 });
-                console.log('Đã cập nhật thông tin trận đấu:', {
+
+                // Console log để debug
+                console.log('🎨 [DEBUG] Team kit colors updated:', teamColorsData);
+                console.log('📡 [DEBUG] Emitted match_info_update với data:', {
                   teamAInfo,
                   teamBInfo,
                   matchInfo,
+                  teamColors: teamColorsData,
                   logoA: teamAInfo.logo || matchData.teamA.logo,
                   logoB: teamBInfo.logo || matchData.teamB.logo
                 });
-                toast.success('✅ Đã cập nhật thông tin trận đấu thành công!');
+                toast.success('✅ Đã cập nhật thông tin trận đấu và màu áo thành công!');
               }}
               className="px-3 py-1 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-bold text-xs rounded shadow transform hover:scale-105 transition-all duration-200"
             >
@@ -1336,6 +1345,29 @@ const MatchManagementSection = ({ isActive = true }) => {
             <Button
               variant="primary"
               size="sm"
+              onClick={() => {
+                // Tạo marquee data từ clock settings
+                const marqueeSettings = {
+                  text: clockText || "TRỰC TIẾP BÓNG ĐÁ",
+                  mode: clockSetting,
+                  color: tickerColor,
+                  interval: clockSetting === 'moi-2' ? 2 : clockSetting === 'moi-5' ? 5 : 0
+                };
+
+                // Update marquee qua MatchContext
+                updateMarquee(marqueeSettings);
+
+                // Console log để debug
+                console.log('🎬 [DEBUG] Clock Settings applied:', {
+                  clockSetting,
+                  clockText,
+                  tickerColor,
+                  marqueeSettings
+                });
+                console.log('📡 [DEBUG] Emitted marquee_update với data:', marqueeSettings);
+
+                toast.success('✅ Đã áp dụng cài đặt chữ chạy!');
+              }}
               className="px-4 py-1 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-medium text-xs rounded-lg shadow-lg transform hover:scale-105 transition-all duration-200"
             >
               ÁP DỤNG


### PR DESCRIPTION
## Purpose
The user requested fixes for the match management system to properly handle team kit colors and marquee text settings. They wanted to ensure that team kit colors selected in the match info section are properly displayed in the scoreboard, and that the marquee text settings from Clock Settings are properly applied instead of using hardcoded values.

## Code changes

### ScoreboardBelowNew.jsx
- **Team kit colors**: Updated to use `matchData.teamAKitColor` and `matchData.teamBKitColor` from match context instead of hardcoded colors
- **Marquee settings**: Enhanced marquee data handling to support different color schemes (white-black, black-white, white-blue, white-red, white-green) with proper text and background color mapping
- **Dynamic styling**: Added support for marquee mode from context data

### MatchManagementSection.jsx
- **Team colors emission**: Added socket emission for team kit colors when "Áp dụng" button is clicked in match info section
- **Context updates**: Updated `updateMatchInfo` to include team kit colors in match context
- **Clock settings handler**: Implemented click handler for "Áp dụng" button in Clock Settings section to emit marquee updates
- **Debug logging**: Added comprehensive console logging for both team colors and marquee settings updates
- **Toast notifications**: Added success messages for both team kit colors and marquee settings updates

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 116`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2576c8bf95cc46aeabeea17c38b35705/quantum-zone)

👀 [Preview Link](https://2576c8bf95cc46aeabeea17c38b35705-quantum-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2576c8bf95cc46aeabeea17c38b35705</projectId>-->
<!--<branchName>quantum-zone</branchName>-->