### PR TITLE
Fix team logos and scrolling text timing controls

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -63,6 +63,35 @@ const ScoreboardBelowNew = ({
         }
     }, [displaySettings?.selectedSkin]);
 
+    // Handle scrolling text visibility based on mode and timing
+    useEffect(() => {
+        let timer;
+
+        if (scrollData.mode === 'khong') {
+            // Hide scrolling text for 'KHÔNG' mode
+            setShowScrollingText(false);
+        } else if (scrollData.mode === 'lien-tuc') {
+            // Show every 30 seconds for 'LIÊN TỤC' mode
+            setShowScrollingText(true);
+            timer = setInterval(() => {
+                setShowScrollingText(false);
+                setTimeout(() => setShowScrollingText(true), 2000); // Hide for 2 seconds then show again
+            }, scrollData.interval);
+        } else if (scrollData.mode === 'moi-2' || scrollData.mode === 'moi-5') {
+            // Show at specified intervals for 'MỖI 2\'' and 'MỖI 5\'' modes
+            timer = setInterval(() => {
+                setShowScrollingText(true);
+                setTimeout(() => setShowScrollingText(false), 5000); // Show for 5 seconds
+            }, scrollData.interval);
+        }
+
+        return () => {
+            if (timer) {
+                clearInterval(timer);
+            }
+        };
+    }, [scrollData.mode, scrollData.interval]);
+
     // Hàm tính độ sáng của màu để chọn màu chữ phù hợp
     const getTextColor = (backgroundColor) => {
         const hex = backgroundColor.replace('#', '');

--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -494,18 +494,20 @@ const ScoreboardBelowNew = ({
                     </div>
                 </div>
 
-                {/* Scrolling Text */}
-                <div className="absolute bottom-0 left-0 w-full z-20 overflow-hidden" style={{ backgroundColor: scrollData.bgColor }}>
-                    <div
-                        className="animate-scroll whitespace-nowrap py-2 text-sm font-semibold"
-                        style={{
-                            color: scrollData.color,
-                            animation: 'scroll 30s linear infinite'
-                        }}
-                    >
-                        {Array(scrollData.repeat).fill(scrollData.text).join(' • ')}
+                {/* Scrolling Text - only show if mode is not 'khong' and visibility is true */}
+                {scrollData.mode !== 'khong' && showScrollingText && (
+                    <div className="absolute bottom-0 left-0 w-full z-20 overflow-hidden" style={{ backgroundColor: scrollData.bgColor }}>
+                        <div
+                            className="animate-scroll whitespace-nowrap py-2 text-sm font-semibold"
+                            style={{
+                                color: scrollData.color,
+                                animation: 'scroll 30s linear infinite'
+                            }}
+                        >
+                            {Array(scrollData.repeat).fill(scrollData.text).join(' • ')}
+                        </div>
                     </div>
-                </div>
+                )}
             </div>
 
             <style jsx>{`

--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -30,9 +30,12 @@ const ScoreboardBelowNew = ({
         leagueLogo: "/api/placeholder/40/40"
     };
 
+    // State for scrolling text visibility control
+    const [showScrollingText, setShowScrollingText] = useState(false);
+
     // Get marquee data from context (updated via Clock Settings)
     const scrollData = {
-        text: marqueeData?.text || "TRỰC TI��P BÓNG ĐÁ",
+        text: marqueeData?.text || "TRỰC TIẾP BÓNG ĐÁ",
         color: marqueeData?.color === 'white-black' ? '#FFFFFF' :
                marqueeData?.color === 'black-white' ? '#000000' :
                marqueeData?.color === 'white-blue' ? '#FFFFFF' :
@@ -44,7 +47,10 @@ const ScoreboardBelowNew = ({
                  marqueeData?.color === 'white-red' ? '#dc2626' :
                  marqueeData?.color === 'white-green' ? '#16a34a' : "#FF0000",
         repeat: 3,
-        mode: marqueeData?.mode || 'none'
+        mode: marqueeData?.mode || 'khong',
+        interval: marqueeData?.mode === 'moi-2' ? 120000 : // 2 minutes = 120 seconds
+                  marqueeData?.mode === 'moi-5' ? 300000 : // 5 minutes = 300 seconds
+                  marqueeData?.mode === 'lien-tuc' ? 30000 : 0 // liên tục = 30 seconds
     };
 
     // Determine if we should show match time based on status

--- a/src/components/sections/MatchManagementSection.jsx
+++ b/src/components/sections/MatchManagementSection.jsx
@@ -689,7 +689,7 @@ const MatchManagementSection = ({ isActive = true }) => {
                   teamBKitColor: teamBInfo.shirtColor || '#000000'
                 };
 
-                // Update team kit colors in MatchContext
+                // Update team kit colors in MatchContext with logo URLs
                 updateMatchInfo({
                   ...teamColorsData,
                   startTime: matchInfo.startTime,
@@ -697,7 +697,9 @@ const MatchManagementSection = ({ isActive = true }) => {
                   matchDate: matchInfo.matchDate || new Date().toISOString().split('T')[0],
                   title: matchTitle,
                   time: matchInfo.startTime,
-                  liveUnit: liveUnit
+                  liveUnit: liveUnit,
+                  logoTeamA: teamAInfo.logo || matchData.teamA.logo || "",
+                  logoTeamB: teamBInfo.logo || matchData.teamB.logo || ""
                 });
 
                 // Console log để debug

--- a/src/contexts/PublicMatchContext.jsx
+++ b/src/contexts/PublicMatchContext.jsx
@@ -31,7 +31,9 @@ export const PublicMatchProvider = ({ children }) => {
     tournament: "",
     stadium: "",
     matchDate: "",
-    liveText: ""
+    liveText: "",
+    teamAKitColor: "#FF0000", // Default team A kit color
+    teamBKitColor: "#0000FF"  // Default team B kit color
   });
 
   // State cho thống kê trận đấu


### PR DESCRIPTION
## Purpose

The user identified several issues with the scoreboard system:
- Team logos (logoTeamA and logoTeamB) were not being properly passed from match management to the scoreboard component, resulting in null values
- Scrolling text was always visible instead of being controlled by clock settings
- Scrolling text timing intervals were not matching the expected behavior (30s for continuous, 120s for 2-minute intervals, 300s for 5-minute intervals)
- Team kit colors were not updating correctly despite backend receiving proper emit events

## Code changes

**MatchManagementSection.jsx:**
- Added `logoTeamA` and `logoTeamB` properties to the `updateMatchInfo` call to properly pass team logo URLs to the scoreboard component

**ScoreboardBelowNew.jsx:**
- Added `showScrollingText` state to control scrolling text visibility
- Implemented proper timing intervals: 30s for continuous mode, 120s for 2-minute mode, 300s for 5-minute mode
- Added useEffect hook to handle scrolling text visibility based on selected mode
- Modified scrolling text rendering to only show when mode is not 'khong' and visibility state is true
- Fixed text encoding issue (changed "TRỰC TI��P" to "TRỰC TIẾP")

**PublicMatchContext.jsx:**
- Added default team kit colors (`teamAKitColor` and `teamBKitColor`) to the initial match info state to ensure proper color handling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 117`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8fe1ec3578d84a60b101a3938018233d/stellar-haven)

👀 [Preview Link](https://8fe1ec3578d84a60b101a3938018233d-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8fe1ec3578d84a60b101a3938018233d</projectId>-->
<!--<branchName>stellar-haven</branchName>-->