### PR TITLE
Fix scoreboard positioning and mobile scaling in ScoreboardAbove

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -586,31 +586,26 @@ const ScoreboardAbove = ({
                     animation: scroll 30s linear infinite;
                 }
 
-                /* Mobile scaling - keep scoreboard in top-right with proportional scaling */
+                /* Uniform scaling for mobile - like image zoom while staying top-right */
                 .scoreboard-main {
                     transform-origin: top right;
                 }
 
                 @media (max-width: 768px) {
                     .scoreboard-main {
-                        transform: scale(0.8);
-                    }
-
-                    .container-name-color-left,
-                    .container-name-color-right {
-                        min-width: 60px;
+                        transform: scale(0.75);
                     }
                 }
 
                 @media (max-width: 480px) {
                     .scoreboard-main {
-                        transform: scale(0.65);
+                        transform: scale(0.6);
                     }
                 }
 
                 @media (max-width: 360px) {
                     .scoreboard-main {
-                        transform: scale(0.55);
+                        transform: scale(0.5);
                     }
                 }
             `}</style>

--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -528,8 +528,8 @@ const ScoreboardAbove = ({
                 )}
 
                 {/* Main Scoreboard - Top Right */}
-                <div className="absolute top-8 right-8 z-30">
-                    <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl min-w-[400px] py-3">
+                <div className="absolute top-4 right-4 z-30 transform-gpu origin-top-right">
+                    <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl">
                         {renderScoreboard()}
                     </div>
                 </div>

--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -320,7 +320,7 @@ const ScoreboardAbove = ({
             {!showMatchTime && (
                 <div className="text-center mt-2">
                     <span className="bg-green-600 text-white px-4 py-1 text-sm font-bold rounded animate-pulse">
-                        ● TRỰC TIẾP
+                        ● TR���C TIẾP
                     </span>
                 </div>
             )}
@@ -495,11 +495,8 @@ const ScoreboardAbove = ({
 
     return (
         <div className="w-full h-screen relative overflow-hidden">
-            {/* Container that scales for mobile while maintaining proportions */}
-            <div className="w-full h-full relative bg-transparent" style={{
-                transform: 'scale(var(--scale-factor, 1))',
-                transformOrigin: 'center center'
-            }}>
+            {/* Container for all elements */}
+            <div className="w-full h-full relative bg-transparent">
                 {/* Sponsors - Top Left */}
                 <div className="absolute top-4 left-4 z-40">
                     {sponsors?.url_logo && sponsors.url_logo.length > 0 && (

--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -320,7 +320,7 @@ const ScoreboardAbove = ({
             {!showMatchTime && (
                 <div className="text-center mt-2">
                     <span className="bg-green-600 text-white px-4 py-1 text-sm font-bold rounded animate-pulse">
-                        ● TR���C TIẾP
+                        ● TRỰC TIẾP
                     </span>
                 </div>
             )}
@@ -525,7 +525,7 @@ const ScoreboardAbove = ({
                 )}
 
                 {/* Main Scoreboard - Top Right */}
-                <div className="absolute top-4 right-4 z-30 transform-gpu origin-top-right">
+                <div className="absolute top-4 right-4 z-30">
                     <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl">
                         {renderScoreboard()}
                     </div>

--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -588,27 +588,32 @@ const ScoreboardAbove = ({
                 .animate-scroll {
                     animation: scroll 30s linear infinite;
                 }
-                
-                /* Mobile scaling for proportional zoom */
+
+                /* Mobile scaling - keep scoreboard in top-right with proportional scaling */
+                .scoreboard-main {
+                    transform-origin: top right;
+                }
+
                 @media (max-width: 768px) {
-                    :root {
-                        --scale-factor: 0.85;
-                    }
-                    
                     .scoreboard-main {
-                        min-width: 350px;
-                        max-width: 95vw;
+                        transform: scale(0.8);
                     }
-                    
+
                     .container-name-color-left,
                     .container-name-color-right {
                         min-width: 60px;
                     }
                 }
-                
+
                 @media (max-width: 480px) {
-                    :root {
-                        --scale-factor: 0.75;
+                    .scoreboard-main {
+                        transform: scale(0.65);
+                    }
+                }
+
+                @media (max-width: 360px) {
+                    .scoreboard-main {
+                        transform: scale(0.55);
                     }
                 }
             `}</style>

--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -361,7 +361,7 @@ const ScoreboardAbove = ({
                         </div>
                     )}
                     {!showMatchTime && (
-                        <div className="bg-green-600 text-white px-2 py-0.5 text-xs font-medium rounded-sm mt-1 animate-pulse">
+                        <div className="bg-green-600 text-white px-2 py-0.5 text-[10px] font-medium rounded-sm mt-1 animate-pulse whitespace-nowrap">
                             ● TRỰC TIẾP
                         </div>
                     )}

--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -491,11 +491,8 @@ const ScoreboardBelowNew = ({
 
     return (
         <div className="w-full h-screen relative overflow-hidden">
-            {/* Container that scales for mobile while maintaining proportions */}
-            <div className="w-full h-full relative bg-transparent" style={{
-                transform: 'scale(var(--scale-factor, 1))',
-                transformOrigin: 'center center'
-            }}>
+            {/* Container for all elements */}
+            <div className="w-full h-full relative bg-transparent">
                 {/* ScoLiv Logo - Responsive cho desktop và mobile */}
                 <div className="absolute bottom-4 left-4 sm:left-16 z-40">
                     <img

--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -357,7 +357,7 @@ const ScoreboardBelowNew = ({
                         </div>
                     )}
                     {!showMatchTime && (
-                        <div className="bg-green-600 text-white px-2 py-0.5 text-xs font-medium rounded-sm mt-1 animate-pulse">
+                        <div className="bg-green-600 text-white px-2 py-0.5 text-[10px] font-medium rounded-sm mt-1 animate-pulse whitespace-nowrap">
                             ● TRỰC TIẾP
                         </div>
                     )}

--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -536,30 +536,30 @@ const ScoreboardBelowNew = ({
                 .animate-scroll {
                     animation: scroll 30s linear infinite;
                 }
-                
-                /* Mobile scaling for proportional zoom */
+
+                /* Uniform scaling for mobile - like image zoom while staying centered bottom */
+                .scoreboard-main {
+                    transform-origin: bottom center;
+                }
+
                 @media (max-width: 768px) {
-                    :root {
-                        --scale-factor: 0.85;
-                    }
-                    
                     .scoreboard-main {
-                        min-width: 350px;
-                        max-width: 95vw;
-                    }
-                    
-                    .container-name-color-left,
-                    .container-name-color-right {
-                        min-width: 60px;
+                        transform: scale(0.75);
                     }
                 }
-                
+
                 @media (max-width: 480px) {
-                    :root {
-                        --scale-factor: 0.75;
+                    .scoreboard-main {
+                        transform: scale(0.6);
                     }
                 }
-                
+
+                @media (max-width: 360px) {
+                    .scoreboard-main {
+                        transform: scale(0.5);
+                    }
+                }
+
                 /* Logo styling to prevent corner cutting */
                 .logo-container {
                     border-radius: 50%;

--- a/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
+++ b/src/components/scoreboard_preview/ScoreboardBelowNew.jsx
@@ -507,7 +507,7 @@ const ScoreboardBelowNew = ({
 
                 {/* Main Scoreboard */}
                 <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-30">
-                    <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl min-w-[400px] py-3">
+                    <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl">
                         {renderScoreboard()}
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose
Fix the scoreboard interface in ScoreBoardAbove.jsx to ensure the scoreboard always stays positioned in the top-right corner. On mobile devices, the scoreboard should scale down proportionally without changing aspect ratio or shifting to the center of the screen, maintaining its top-right position.

## Code changes
- **Removed container-level scaling**: Eliminated the transform scale wrapper that was causing the scoreboard to center on mobile
- **Updated positioning**: Changed scoreboard container from `top-8 right-8` to `top-4 right-4` for tighter corner positioning
- **Added transform-origin**: Set `origin-top-right` and `transform-origin: top right` to ensure scaling happens from the top-right corner
- **Implemented responsive scaling**: Added media queries with direct transform scale values:
  - Mobile (≤768px): scale(0.8)
  - Small mobile (≤480px): scale(0.65) 
  - Extra small (≤360px): scale(0.55)
- **Removed min-width constraints**: Eliminated fixed width restrictions that were interfering with proper scaling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 122`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8fe1ec3578d84a60b101a3938018233d/curry-verse)

👀 [Preview Link](https://8fe1ec3578d84a60b101a3938018233d-curry-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8fe1ec3578d84a60b101a3938018233d</projectId>-->
<!--<branchName>curry-verse</branchName>-->