### PR TITLE
Fix position array handling for sponsors and organizing logos

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -499,9 +499,9 @@ const ScoreboardAbove = ({
                 <div className="absolute top-4 left-4 z-40">
                     {/* Sponsors with top-left position */}
                     {sponsors?.url_logo && sponsors.url_logo.length > 0 && sponsors?.position &&
-                     sponsors.position.some(pos => pos === 'top-left') && (
+                     sponsors.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'top-left') && (
                         <DisplayLogo
-                            logos={sponsors.url_logo.filter((_, index) => sponsors.position[index] === 'top-left')}
+                            logos={sponsors.url_logo.filter((_, index) => (Array.isArray(sponsors.position[index]) ? sponsors.position[index][0] : sponsors.position[index]) === 'top-left')}
                             alt="Sponsors"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -513,9 +513,9 @@ const ScoreboardAbove = ({
 
                     {/* Organizing with top-left position */}
                     {organizing?.url_logo && organizing.url_logo.length > 0 && organizing?.position &&
-                     organizing.position.some(pos => pos === 'top-left') && (
+                     organizing.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'top-left') && (
                         <DisplayLogo
-                            logos={organizing.url_logo.filter((_, index) => organizing.position[index] === 'top-left')}
+                            logos={organizing.url_logo.filter((_, index) => (Array.isArray(organizing.position[index]) ? organizing.position[index][0] : organizing.position[index]) === 'top-left')}
                             alt="Organizing"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -527,9 +527,9 @@ const ScoreboardAbove = ({
 
                     {/* Media Partners with top-left position */}
                     {mediaPartners?.url_logo && mediaPartners.url_logo.length > 0 && mediaPartners?.position &&
-                     mediaPartners.position.some(pos => pos === 'top-left') && (
+                     mediaPartners.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'top-left') && (
                         <DisplayLogo
-                            logos={mediaPartners.url_logo.filter((_, index) => mediaPartners.position[index] === 'top-left')}
+                            logos={mediaPartners.url_logo.filter((_, index) => (Array.isArray(mediaPartners.position[index]) ? mediaPartners.position[index][0] : mediaPartners.position[index]) === 'top-left')}
                             alt="Media Partners"
                             className="w-16 h-16"
                             type_play={logoShape}

--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -576,9 +576,9 @@ const ScoreboardAbove = ({
                 <div className="absolute bottom-4 left-4 z-40">
                     {/* Sponsors with bottom-left position */}
                     {sponsors?.url_logo && sponsors.url_logo.length > 0 && sponsors?.position &&
-                     sponsors.position.some(pos => pos === 'bottom-left') && (
+                     sponsors.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'bottom-left') && (
                         <DisplayLogo
-                            logos={sponsors.url_logo.filter((_, index) => sponsors.position[index] === 'bottom-left')}
+                            logos={sponsors.url_logo.filter((_, index) => (Array.isArray(sponsors.position[index]) ? sponsors.position[index][0] : sponsors.position[index]) === 'bottom-left')}
                             alt="Sponsors"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -590,9 +590,9 @@ const ScoreboardAbove = ({
 
                     {/* Organizing with bottom-left position */}
                     {organizing?.url_logo && organizing.url_logo.length > 0 && organizing?.position &&
-                     organizing.position.some(pos => pos === 'bottom-left') && (
+                     organizing.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'bottom-left') && (
                         <DisplayLogo
-                            logos={organizing.url_logo.filter((_, index) => organizing.position[index] === 'bottom-left')}
+                            logos={organizing.url_logo.filter((_, index) => (Array.isArray(organizing.position[index]) ? organizing.position[index][0] : organizing.position[index]) === 'bottom-left')}
                             alt="Organizing"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -604,9 +604,9 @@ const ScoreboardAbove = ({
 
                     {/* Media Partners with bottom-left position */}
                     {mediaPartners?.url_logo && mediaPartners.url_logo.length > 0 && mediaPartners?.position &&
-                     mediaPartners.position.some(pos => pos === 'bottom-left') && (
+                     mediaPartners.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'bottom-left') && (
                         <DisplayLogo
-                            logos={mediaPartners.url_logo.filter((_, index) => mediaPartners.position[index] === 'bottom-left')}
+                            logos={mediaPartners.url_logo.filter((_, index) => (Array.isArray(mediaPartners.position[index]) ? mediaPartners.position[index][0] : mediaPartners.position[index]) === 'bottom-left')}
                             alt="Media Partners"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -634,9 +634,9 @@ const ScoreboardAbove = ({
                 <div className="absolute bottom-4 right-4 z-40">
                     {/* Sponsors with bottom-right position */}
                     {sponsors?.url_logo && sponsors.url_logo.length > 0 && sponsors?.position &&
-                     sponsors.position.some(pos => pos === 'bottom-right') && (
+                     sponsors.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'bottom-right') && (
                         <DisplayLogo
-                            logos={sponsors.url_logo.filter((_, index) => sponsors.position[index] === 'bottom-right')}
+                            logos={sponsors.url_logo.filter((_, index) => (Array.isArray(sponsors.position[index]) ? sponsors.position[index][0] : sponsors.position[index]) === 'bottom-right')}
                             alt="Sponsors"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -648,9 +648,9 @@ const ScoreboardAbove = ({
 
                     {/* Organizing with bottom-right position */}
                     {organizing?.url_logo && organizing.url_logo.length > 0 && organizing?.position &&
-                     organizing.position.some(pos => pos === 'bottom-right') && (
+                     organizing.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'bottom-right') && (
                         <DisplayLogo
-                            logos={organizing.url_logo.filter((_, index) => organizing.position[index] === 'bottom-right')}
+                            logos={organizing.url_logo.filter((_, index) => (Array.isArray(organizing.position[index]) ? organizing.position[index][0] : organizing.position[index]) === 'bottom-right')}
                             alt="Organizing"
                             className="w-16 h-16"
                             type_play={logoShape}
@@ -662,9 +662,9 @@ const ScoreboardAbove = ({
 
                     {/* Media Partners with bottom-right position */}
                     {mediaPartners?.url_logo && mediaPartners.url_logo.length > 0 && mediaPartners?.position &&
-                     mediaPartners.position.some(pos => pos === 'bottom-right') && (
+                     mediaPartners.position.some((pos, index) => (Array.isArray(pos) ? pos[0] : pos) === 'bottom-right') && (
                         <DisplayLogo
-                            logos={mediaPartners.url_logo.filter((_, index) => mediaPartners.position[index] === 'bottom-right')}
+                            logos={mediaPartners.url_logo.filter((_, index) => (Array.isArray(mediaPartners.position[index]) ? mediaPartners.position[index][0] : mediaPartners.position[index]) === 'bottom-right')}
                             alt="Media Partners"
                             className="w-16 h-16"
                             type_play={logoShape}

--- a/src/contexts/PublicMatchContext.jsx
+++ b/src/contexts/PublicMatchContext.jsx
@@ -285,19 +285,22 @@ export const PublicMatchProvider = ({ children }) => {
 
     // Lắng nghe cập nhật nhà tài trợ
     socketService.on('sponsors_updated', (data) => {
-      setSponsors(prev => ({ ...prev, ...data.sponsors }));
+      console.log('📝 [PublicMatchContext] sponsors_updated received:', data);
+      setSponsors(prev => ({ ...prev, ...data }));
       setLastUpdateTime(Date.now());
     });
 
     // Lắng nghe cập nhật đơn vị tổ chức
     socketService.on('organizing_updated', (data) => {
-      setOrganizings(prev => ({ ...prev, ...data.organizings }));
+      console.log('📝 [PublicMatchContext] organizing_updated received:', data);
+      setOrganizings(prev => ({ ...prev, ...data }));
       setLastUpdateTime(Date.now());
     });
 
     // Lắng nghe cập nhật đơn vị truyền thông
     socketService.on('media_partners_updated', (data) => {
-      setMediaPartners(prev => ({ ...prev, ...data.mediaPartners }));
+      console.log('📝 [PublicMatchContext] media_partners_updated received:', data);
+      setMediaPartners(prev => ({ ...prev, ...data }));
       setLastUpdateTime(Date.now());
     });
 
@@ -321,7 +324,8 @@ export const PublicMatchProvider = ({ children }) => {
 
     // Lắng nghe cập nhật display settings
     socketService.on('display_settings_updated', (data) => {
-      setDisplaySettings(prev => ({ ...prev, ...data.displaySettings }));
+      console.log('📝 [PublicMatchContext] display_settings_updated received:', data);
+      setDisplaySettings(prev => ({ ...prev, ...data }));
       setLastUpdateTime(Date.now());
     });
 


### PR DESCRIPTION
## Purpose

The user needed to fix the mapping of sponsors, organizing, and media partners variables through accurate event handling. The backend was returning position data as nested arrays (e.g., `position: [['bottom-right'], ['bottom-right']]`) from `organizing_updated` and `display_settings_updated` events, but the frontend code was expecting simple string values.

## Code changes

### ScoreboardAbove.jsx
- **Fixed position array handling**: Updated all position checks to handle both array and string formats
- **Modified filtering logic**: Added array detection using `Array.isArray()` to extract the first element when position is an array
- **Applied to all logo types**: Updated sponsors, organizing, and media partners position handling for all positions (top-left, bottom-left, bottom-right)

### PublicMatchContext.jsx
- **Updated socket event handlers**: Fixed data mapping for `sponsors_updated`, `organizing_updated`, `media_partners_updated`, and `display_settings_updated` events
- **Removed nested object access**: Changed from `data.sponsors` to `data` directly to match backend response format
- **Added debug logging**: Included console.log statements to track received data for debugging purposes

The changes ensure proper handling of position data whether it comes as a simple string or nested array format from the backend events.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 125`

🔗 [Edit in Builder.io](https://builder.io/app/projects/44c041da3750417b862b16012dd699d9/vibe-landing)

👀 [Preview Link](https://44c041da3750417b862b16012dd699d9-vibe-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>44c041da3750417b862b16012dd699d9</projectId>-->
<!--<branchName>vibe-landing</branchName>-->