### PR TITLE
Fix logo positioning and display in ScoreboardAbove component

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -579,8 +579,42 @@ const ScoreboardAbove = ({
                     </div>
                 )}
 
+                {/* Top Right Position - Logos first, then scoreboard below */}
+                <div className="absolute top-4 right-4 z-40">
+                    {(() => {
+                        const sponsorsTopRight = filterLogosByPosition(sponsors, 'top-right');
+                        const organizingTopRight = filterLogosByPosition(organizing, 'top-right');
+                        const mediaPartnersTopRight = filterLogosByPosition(mediaPartners, 'top-right');
+
+                        // Combine all top-right logos
+                        const allTopRightLogos = [...sponsorsTopRight, ...organizingTopRight, ...mediaPartnersTopRight];
+
+                        if (allTopRightLogos.length > 0) {
+                            return (
+                                <DisplayLogo
+                                    logos={allTopRightLogos}
+                                    alt="Top Right Logos"
+                                    className="w-16 h-16 mb-2"
+                                    type_play={logoShape}
+                                    slideMode={displaySettings?.rotateDisplay || false}
+                                    maxVisible={3}
+                                    slideInterval={5000}
+                                />
+                            );
+                        }
+
+                        return null;
+                    })()}
+                </div>
+
                 {/* Main Scoreboard - Top Right */}
-                <div className="absolute top-4 right-4 z-30">
+                <div className="absolute top-4 right-4 z-30" style={{ marginTop: (() => {
+                    const sponsorsTopRight = filterLogosByPosition(sponsors, 'top-right');
+                    const organizingTopRight = filterLogosByPosition(organizing, 'top-right');
+                    const mediaPartnersTopRight = filterLogosByPosition(mediaPartners, 'top-right');
+                    const allTopRightLogos = [...sponsorsTopRight, ...organizingTopRight, ...mediaPartnersTopRight];
+                    return allTopRightLogos.length > 0 ? '80px' : '0px';
+                })() }}>
                     <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl">
                         {renderScoreboard()}
                     </div>


### PR DESCRIPTION
## Purpose

The user was experiencing issues with logo display in the ScoreboardAbove component. Despite receiving correct data for organizing, sponsors, mediaPartners, and tournamentLogo with proper position values (top-left, bottom-right, etc.), the logos were not updating correctly on the interface. The user needed to fix the logo positioning logic to properly handle nested array structures in position data.

## Code changes

- **Added debug logging**: Added useEffect to log all logo data (organizing, sponsors, mediaPartners, tournamentLogo) for troubleshooting
- **Created helper functions**: 
  - `getPosition()` to handle nested array position values (e.g., `[["top-left"]]` → `"top-left"`)
  - `filterLogosByPosition()` to filter logos by their target position with proper array handling
- **Refactored logo rendering logic**: Replaced repetitive conditional rendering with consolidated IIFE (Immediately Invoked Function Expression) blocks for each position
- **Combined logo sources**: Each position now combines logos from all sources (sponsors, organizing, mediaPartners) into a single DisplayLogo component
- **Fixed top-right positioning**: Added proper spacing between top-right logos and the main scoreboard using dynamic margin calculation
- **Improved fallback handling**: Maintained fallback logic for logos without position data while consolidating the code structure

The changes ensure logos are properly filtered by position and displayed correctly regardless of whether position data is stored as simple strings or nested arrays.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 127`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b0f639af66d74ab09b775755c37ec713/zenith-lab)

👀 [Preview Link](https://b0f639af66d74ab09b775755c37ec713-zenith-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b0f639af66d74ab09b775755c37ec713</projectId>-->
<!--<branchName>zenith-lab</branchName>-->