### PR TITLE
Remove React.StrictMode wrapper from app root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,9 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
-  </React.StrictMode>
+  <BrowserRouter>
+    <AppRoutes />
+  </BrowserRouter>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
## Purpose
The user wanted to remove React.StrictMode from the entire application during development to prevent duplicate API requests. React.StrictMode intentionally double-invokes components and effects in development mode to help detect side effects, but this was causing unwanted duplicate network requests during development.

## Code changes
- Removed `<React.StrictMode>` wrapper from the root render in `src/index.js`
- App now renders `<BrowserRouter>` and `<AppRoutes />` directly without the StrictMode wrapper
- This prevents React from double-invoking effects and components during development

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 131`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dfce8163f61b47be90b069005379cd48/flare-zone)

👀 [Preview Link](https://dfce8163f61b47be90b069005379cd48-flare-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dfce8163f61b47be90b069005379cd48</projectId>-->
<!--<branchName>flare-zone</branchName>-->