### PR TITLE
Fix responsive layout for corner logos in ScoreboardAbove

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -551,15 +551,15 @@ const ScoreboardAbove = ({
 
     return (
         <div className="w-full h-screen relative overflow-hidden">
-            <div className="w-full h-full relative bg-transparent">
+            <div className="w-full h-full relative bg-transparent scoreboard-container">
                 {/* Top Left Position */}
-                <div className="absolute top-4 left-4 z-40">
+                <div className="absolute top-4 left-4 z-40 corner-logo top-left">
                     {renderLogos(collectLogosForPosition('top-left'))}
                 </div>
 
                 {/* Tournament Logo - Top Left (if no sponsors) */}
                 {collectLogosForPosition('top-left').length === 0 && tournamentLogo?.url_logo && tournamentLogo.url_logo.length > 0 && (
-                    <div className="absolute top-4 left-4 z-40">
+                    <div className="absolute top-4 left-4 z-40 corner-logo top-left">
                         <DisplayLogo
                             logos={tournamentLogo.url_logo}
                             alt="Tournament"
@@ -570,19 +570,19 @@ const ScoreboardAbove = ({
                 )}
 
                 {/* Main Scoreboard - Top Right */}
-                <div className="absolute top-4 right-4 z-30">
+                <div className="absolute top-4 right-4 z-30 scoreboard-position">
                     <div className="scoreboard-main bg-transparent rounded-lg shadow-2xl">
                         {renderScoreboard()}
                     </div>
                 </div>
 
                 {/* Bottom Left Position */}
-                <div className="absolute bottom-4 left-4 z-40">
+                <div className="absolute bottom-4 left-4 z-40 corner-logo bottom-left">
                     {renderLogos(collectLogosForPosition('bottom-left'))}
                 </div>
 
                 {/* Bottom Right Position */}
-                <div className="absolute bottom-4 right-4 z-40">
+                <div className="absolute bottom-4 right-4 z-40 corner-logo bottom-right">
                     {renderLogos(collectLogosForPosition('bottom-right'))}
                 </div>
 
@@ -615,21 +615,89 @@ const ScoreboardAbove = ({
                     transform-origin: top right;
                 }
 
+                .corner-logo {
+                    transform-origin: center;
+                }
+
+                .scoreboard-position {
+                    transform-origin: top right;
+                }
+
+                /* Tablet */
                 @media (max-width: 768px) {
                     .scoreboard-main {
                         transform: scale(0.75);
                     }
+                    .corner-logo {
+                        transform: scale(0.75);
+                    }
+                    .corner-logo.top-left {
+                        top: 12px;
+                        left: 12px;
+                    }
+                    .corner-logo.bottom-left {
+                        bottom: 12px;
+                        left: 12px;
+                    }
+                    .corner-logo.bottom-right {
+                        bottom: 12px;
+                        right: 12px;
+                    }
+                    .scoreboard-position {
+                        top: 12px;
+                        right: 12px;
+                    }
                 }
 
+                /* Mobile */
                 @media (max-width: 480px) {
                     .scoreboard-main {
                         transform: scale(0.6);
                     }
+                    .corner-logo {
+                        transform: scale(0.6);
+                    }
+                    .corner-logo.top-left {
+                        top: 8px;
+                        left: 8px;
+                    }
+                    .corner-logo.bottom-left {
+                        bottom: 8px;
+                        left: 8px;
+                    }
+                    .corner-logo.bottom-right {
+                        bottom: 8px;
+                        right: 8px;
+                    }
+                    .scoreboard-position {
+                        top: 8px;
+                        right: 8px;
+                    }
                 }
 
+                /* Small Mobile */
                 @media (max-width: 360px) {
                     .scoreboard-main {
                         transform: scale(0.5);
+                    }
+                    .corner-logo {
+                        transform: scale(0.5);
+                    }
+                    .corner-logo.top-left {
+                        top: 6px;
+                        left: 6px;
+                    }
+                    .corner-logo.bottom-left {
+                        bottom: 6px;
+                        left: 6px;
+                    }
+                    .corner-logo.bottom-right {
+                        bottom: 6px;
+                        right: 6px;
+                    }
+                    .scoreboard-position {
+                        top: 6px;
+                        right: 6px;
                     }
                 }
             `}</style>


### PR DESCRIPTION
## Purpose
Fix responsive layout issues in ScoreboardAbove component where corner logos were overlapping with the main scoreboard on mobile devices. The user reported that logos were stacking on top of each other when the screen width and height were reduced, breaking the intended proportional spacing.

## Code changes
- Added CSS classes (`corner-logo`, `scoreboard-position`) to all positioned elements for better targeting
- Implemented responsive scaling for corner logos matching the scoreboard scaling ratios (0.75x, 0.6x, 0.5x)
- Added responsive positioning adjustments for all breakpoints:
  - Tablet (768px): 12px margins
  - Mobile (480px): 8px margins  
  - Small mobile (360px): 6px margins
- Applied consistent transform-origin settings to ensure proper scaling behavior
- Maintained proportional spacing between logos and scoreboard across all screen sizes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 134`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dfce8163f61b47be90b069005379cd48/stellar-forge)

👀 [Preview Link](https://dfce8163f61b47be90b069005379cd48-stellar-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dfce8163f61b47be90b069005379cd48</projectId>-->
<!--<branchName>stellar-forge</branchName>-->