### PR TITLE
Fix sponsor logo rotation using nested displaySettings

### DIFF
--- a/src/components/scoreboard_preview/ScoreboardAbove.jsx
+++ b/src/components/scoreboard_preview/ScoreboardAbove.jsx
@@ -178,7 +178,7 @@ const ScoreboardAbove = ({
             }
         };
 
-        if (displaySettings?.rotateDisplay && allLogos.length > 1) {
+        if ((displaySettings?.displaySettings?.rotateDisplay || displaySettings?.rotateDisplay) && allLogos.length > 1) {
             // Slide mode - luân phiên hiển thị 3 logo 1 lần
             return (
                 <DisplayLogo


### PR DESCRIPTION
## Purpose

The user identified an issue where sponsor logo rotation wasn't working as expected in ScoreboardAbove.jsx. The component was reading configuration from the wrong level of the displaySettings object. The user wanted:
- Logo rotation to use values from the nested `displaySettings.displaySettings` object
- When `rotateDisplay` is true, show 3 logos at a time in rotation instead of 1
- Logo shape configuration to also use the nested settings

## Code changes

- **Fixed configuration reading**: Updated `logoShape` and `rotateDisplay` to prioritize values from `displaySettings.displaySettings` with fallback to the outer level
- **Updated rotation logic**: Changed `maxVisible` from 1 to 3 logos to display 3 sponsor logos at once during rotation
- **Improved fallback chain**: Added proper fallback logic for both `logoShape` and `rotateDisplay` properties
- **Updated comments**: Changed comment from "quay từng logo một" to "luân phiên hiển thị 3 logo 1 lần" to reflect the new behavior

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 155`

🔗 [Edit in Builder.io](https://builder.io/app/projects/03487cf9298d4c88ba841fd6484f2b83/flare-zone)

👀 [Preview Link](https://03487cf9298d4c88ba841fd6484f2b83-flare-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>03487cf9298d4c88ba841fd6484f2b83</projectId>-->
<!--<branchName>flare-zone</branchName>-->