### PR TITLE
Fix logo positioning on initial room join in display controller

### DIFF
--- a/src/contexts/PublicMatchContext.jsx
+++ b/src/contexts/PublicMatchContext.jsx
@@ -647,6 +647,55 @@ export const PublicMatchProvider = ({ children }) => {
           if (state.displaySettings) {
             console.log('🎨 [PublicMatchContext] Updating displaySettings from join_roomed:', state.displaySettings);
             setDisplaySettings(prev => ({ ...prev, ...state.displaySettings }));
+
+            // Process logos from displaySettings.logos if they exist
+            if (state.displaySettings.logos && Array.isArray(state.displaySettings.logos)) {
+              console.log('🔄 [PublicMatchContext] Processing logos from displaySettings:', state.displaySettings.logos);
+
+              // Separate logos by type
+              const sponsorLogos = state.displaySettings.logos.filter(logo => logo.type === 'sponsors');
+              const organizingLogos = state.displaySettings.logos.filter(logo => logo.type === 'organizing');
+              const mediaPartnerLogos = state.displaySettings.logos.filter(logo => logo.type === 'media_partners');
+
+              // Update sponsors if found
+              if (sponsorLogos.length > 0) {
+                const sponsorData = {
+                  url_logo: sponsorLogos.map(logo => logo.urlLogo),
+                  code_logo: sponsorLogos.map(logo => logo.codelogo),
+                  position: sponsorLogos.map(logo => logo.position),
+                  type_display: sponsorLogos.map(logo => logo.typeDisplay || 'square'),
+                  behavior: 'add'
+                };
+                console.log('🏢 [PublicMatchContext] Setting sponsors from logos:', sponsorData);
+                setSponsors({ sponsors: sponsorData });
+              }
+
+              // Update organizing if found
+              if (organizingLogos.length > 0) {
+                const organizingData = {
+                  url_logo: organizingLogos.map(logo => logo.urlLogo),
+                  code_logo: organizingLogos.map(logo => logo.codelogo),
+                  position: organizingLogos.map(logo => logo.position),
+                  type_display: organizingLogos.map(logo => logo.typeDisplay || 'square'),
+                  behavior: 'add'
+                };
+                console.log('🏛️ [PublicMatchContext] Setting organizing from logos:', organizingData);
+                setOrganizing({ organizing: organizingData });
+              }
+
+              // Update media partners if found
+              if (mediaPartnerLogos.length > 0) {
+                const mediaPartnerData = {
+                  url_logo: mediaPartnerLogos.map(logo => logo.urlLogo),
+                  code_logo: mediaPartnerLogos.map(logo => logo.codelogo),
+                  position: mediaPartnerLogos.map(logo => logo.position),
+                  type_display: mediaPartnerLogos.map(logo => logo.typeDisplay || 'square'),
+                  behavior: 'add'
+                };
+                console.log('📺 [PublicMatchContext] Setting mediaPartners from logos:', mediaPartnerData);
+                setMediaPartners({ mediaPartners: mediaPartnerData });
+              }
+            }
           }
 
           if (state.marqueeData) {


### PR DESCRIPTION
## Purpose

Fix an issue where sponsor, media partner, and organizing logos were not displaying in the correct positions when the display controller loaded for the first time, despite the server data being received correctly during initial room join.

## Code changes

- Added logo processing logic in the `join_roomed` event handler within `PublicMatchContext.jsx`
- Extract and categorize logos by type (sponsors, organizing, media_partners) from `displaySettings.logos`
- Transform logo data into the expected format for each logo type with proper mapping of:
  - `urlLogo` → `url_logo`
  - `codelogo` → `code_logo` 
  - `position` and `typeDisplay` properties
- Set default `typeDisplay` to 'square' when not specified
- Update state for sponsors, organizing, and media partners using their respective setter functions
- Added comprehensive logging for debugging logo processing flow

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 169`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e5330b4eab354adfa4da1dd40de41e41/orbit-home)

👀 [Preview Link](https://e5330b4eab354adfa4da1dd40de41e41-orbit-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5330b4eab354adfa4da1dd40de41e41</projectId>-->
<!--<branchName>orbit-home</branchName>-->