### PR TITLE
Update poster layout: increase font sizes and adjust spacing

### DIFF
--- a/src/pages/Poster-haoquang.jsx
+++ b/src/pages/Poster-haoquang.jsx
@@ -176,22 +176,22 @@ export default function HaoQuangMatchIntro() {
 
         <div className="relative z-10 h-full flex flex-col p-1 sm:p-2">
 
-          {/* Top section với tournament logos only */}
-          <div className="flex justify-center items-start mb-0 sm:mb-1 md:mb-2 min-h-[6vh] sm:min-h-[8vh] md:min-h-[10vh]">
-            {/* Tournament Logos */}
-            <div className={`flex ${getTournamentPositionClass()} items-center gap-1 sm:gap-2 md:gap-4 px-4`}>
-              {matchData.showTournamentLogo && matchData.tournamentLogos && matchData.tournamentLogos.length > 0 &&
-                matchData.tournamentLogos.map((logo, index) => (
+          {/* Top section với tournament logos only - chỉ hiển thị khi có logos */}
+          {matchData.showTournamentLogo && matchData.tournamentLogos && matchData.tournamentLogos.length > 0 && (
+            <div className="flex justify-center items-start mb-0 sm:mb-1 md:mb-2 min-h-[6vh] sm:min-h-[8vh] md:min-h-[10vh]">
+              {/* Tournament Logos */}
+              <div className={`flex ${getTournamentPositionClass()} items-center gap-1 sm:gap-2 md:gap-4 px-4`}>
+                {matchData.tournamentLogos.map((logo, index) => (
                   <img
                     key={index}
                     src={logo}
                     alt={`Tournament Logo ${index + 1}`}
                     className="object-contain h-6 sm:h-8 md:h-12 lg:h-16 max-w-16 sm:max-w-24 md:max-w-32 flex-shrink-0"
                   />
-                ))
-              }
+                ))}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Main content section */}
           <div className="flex-1 flex flex-col justify-center min-h-0">


### PR DESCRIPTION
## Purpose
The user requested improvements to the poster layout in `poster-haoquang.jsx` to enhance visual presentation. The main goals were to:
- Increase font sizes that were too small for readability
- Reduce excessive padding that was causing layout issues
- Bring team sections closer together for better visual balance
- Update the VS image reference and apply new styling to team name containers
- Extend the width of decorative horizontal lines

## Code changes
- **Reduced padding**: Changed container padding from `p-3 sm:p-6` to `p-1 sm:p-2` to minimize excessive top spacing
- **Doubled font sizes**: Increased title font sizes from 32px/7px/20px to 64px/14px/40px across different breakpoints
- **Enhanced team name styling**: Added gradient background, border radius, white border, and increased font sizes for team A and B name containers
- **Reduced team spacing**: Decreased gap between teams from `gap-2 sm:gap-4 md:gap-6` to `gap-1 sm:gap-2 md:gap-3`
- **Extended decorative lines**: Increased horizontal line width from `w-12 sm:w-24` to `w-24 sm:w-48`
- **Updated VS image**: Changed image source from `vs3.png` to `vs2.png`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 207`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e331309257f1486c8a4114ff98ecfb03/stellar-works)

👀 [Preview Link](https://e331309257f1486c8a4114ff98ecfb03-stellar-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e331309257f1486c8a4114ff98ecfb03</projectId>-->
<!--<branchName>stellar-works</branchName>-->