### PR TITLE
Fix spacing and increase logo sizes in Poster-doden

### DIFF
--- a/src/pages/Poster-doden.jsx
+++ b/src/pages/Poster-doden.jsx
@@ -372,9 +372,14 @@ export default function DodenMatchIntro() {
                     />
                   </div>
                 </div>
-                <div className="bg-gradient-to-r from-cyan-500 to-blue-600 px-1 sm:px-2 md:px-3 py-0.5 sm:py-1 md:py-1.5 rounded-md sm:rounded-lg md:rounded-xl shadow-lg border border-white/30 backdrop-blur-sm">
+                <div className="px-1 sm:px-2 md:px-3">
                   <span
-                    className="text-[8px] sm:text-xs md:text-sm lg:text-base font-bold uppercase tracking-wide text-white text-center block truncate"
+                    className="text-[8px] sm:text-xs md:text-sm lg:text-base font-bold uppercase tracking-wide text-center block truncate"
+                    style={{
+                      color: '#ffe006',
+                      fontFamily: "'UTM Colossalis', sans-serif",
+                      textShadow: '2px 2px 4px rgba(0,0,0,0.8)'
+                    }}
                     ref={(el) => el && adjustFontSize(el)}
                   >
                     {matchData.team2}


### PR DESCRIPTION
## Purpose
The user requested improvements to the Poster-doden component layout to address spacing issues and enhance visual presentation. Specifically, they wanted to:
- Reduce excessive spacing between header and title sections
- Eliminate unnecessary gaps in the layout
- Double the size of sponsor and media partner logos for better visibility

## Code changes
- **Reduced header spacing**: Removed `min-h-[6vh]` to `min-h-[14vh]` classes and decreased margin bottom values from `mb-2/mb-3/mb-4` to `mb-1/mb-2/mb-2`
- **Closed gap between sections**: Added negative top margin (`-mt-2 sm:-mt-4 md:-mt-6`) to main content section to bring title closer to header
- **Doubled logo sizes**: 
  - Sponsor logos: increased from `w-5 h-5 sm:w-7 sm:h-7 md:w-9 md:h-9` to `w-10 h-10 sm:w-14 sm:h-14 md:w-18 md:h-18`
  - Media partner logos: increased from `w-6 h-6 sm:w-8 sm:h-8 md:w-10 md:h-10` to `w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20`
- **Updated padding**: Increased logo padding from `p-0.5 sm:p-1` to `p-1 sm:p-2` for better visual balance

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 209`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0e2c2677ba9348c89439514412011f8e/zen-nest)

👀 [Preview Link](https://0e2c2677ba9348c89439514412011f8e-zen-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0e2c2677ba9348c89439514412011f8e</projectId>-->
<!--<branchName>zen-nest</branchName>-->