### PR TITLE
Fix iOS file upload by removing Content-Type header

### DIFF
--- a/src/API/apiLogo.js
+++ b/src/API/apiLogo.js
@@ -29,20 +29,21 @@ const LogoAPI = {
    * @param {string} type - Type of logo ('banner', 'logo','other')
    * @returns {Promise<Object>} The uploaded logo data
    */
-  uploadLogo: async (file, type, name) => {
+  uploadLogo: async (file, type, name, onUploadProgress) => {
     const formData = new FormData();
     formData.append('file', file);
-    formData.append('type', type);
-    formData.append('name', name);
+    if (type) formData.append('type', type);
+    if (name) formData.append('name', name);
 
     try {
-      const response = await api.post('/logos', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
+      const config = {};
+      if (onUploadProgress) config.onUploadProgress = onUploadProgress;
+      // IMPORTANT: do NOT set Content-Type for FormData — let the browser set the boundary automatically
+      const response = await api.post('/logos', formData, config);
       return response.data;
     } catch (error) {
+      console.error('❌ [LogoAPI] uploadLogo error:', error);
+      if (error.request) console.error('❌ [LogoAPI] No response from server. request:', error.request);
       throw LogoAPI.handleError(error);
     }
   },
@@ -101,19 +102,20 @@ const LogoAPI = {
    * @param {string} [data.type] - New logo type (optional)
    * @returns {Promise<Object>} The updated logo data
    */
-  updateLogo: async (id, { file, type }) => {
+  updateLogo: async (id, { file, type }, onUploadProgress) => {
     const formData = new FormData();
     if (file) formData.append('file', file);
     if (type) formData.append('type', type);
 
     try {
-      const response = await api.put(`/logos/${id}`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
+      const config = {};
+      if (onUploadProgress) config.onUploadProgress = onUploadProgress;
+      // Let browser set Content-Type for FormData
+      const response = await api.put(`/logos/${id}`, formData, config);
       return response.data;
     } catch (error) {
+      console.error('❌ [LogoAPI] updateLogo error:', error);
+      if (error.request) console.error('❌ [LogoAPI] No response from server. request:', error.request);
       throw LogoAPI.handleError(error);
     }
   },


### PR DESCRIPTION
## Purpose
Fix iOS file upload issue where logo uploads fail with "no response from server" error while Android uploads work normally. The user reported that other APIs work fine on iOS, but specifically logo upload functionality was broken on iPhone devices.

## Code changes
- **Removed explicit `Content-Type: multipart/form-data` header** from `uploadLogo` and `updateLogo` methods to let the browser automatically set the proper boundary for FormData
- **Added upload progress callback support** with optional `onUploadProgress` parameter
- **Enhanced error logging** with detailed console output to help debug upload failures
- **Made form data parameters optional** with conditional appending for `type` and `name` fields
- **Improved error handling** to specifically log when there's no response from serverTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 244`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cade0b2ea90645479fbe1d881b7f4eaa/vortex-forge)

👀 [Preview Link](https://cade0b2ea90645479fbe1d881b7f4eaa-vortex-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cade0b2ea90645479fbe1d881b7f4eaa</projectId>-->
<!--<branchName>vortex-forge</branchName>-->